### PR TITLE
Mitigate CVE-2017-18214 by updating moment.js to v2.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "knex": "0.12.6",
         "pg": "4.3.0",
         "lodash": "3.9.3",
-        "moment": "2.17.1",
+        "moment": "2.19.3",
         "coffee-script": "1.9.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Before v2.19.3, the moment.js module is prone to a regular expression denial of service via a crafted date string. Although I'm not sure if GER is directly affected, it's dependency on moment.js should be updated regardless as:

1. There are no backwards-incompatible changes between v2.17.1 and v2.19.3

2. Leaving moment.js@2.17.3 will break builds with [NSP](https://github.com/nodesecurity/nsp) enabled.